### PR TITLE
PNDA-4808 Gobblin not pulling data from Kafka

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,7 @@ cd ${BASE}
 
 # Build
 mkdir -p pnda-build
-./gradlew clean findBugsMain pmdMain build -Pversion=${VERSION}
+./gradlew findBugsMain pmdMain build -Pversion=${VERSION}
 cd build/libs
 tar -cvf gobblin-PNDA-${VERSION}.tar.gz *
 cd $BASE


### PR DESCRIPTION
**Analysis**
Currently, Gobblin is not pulling data from Kafka topics and putting into HDFS(/user/pnda/PNDA_datasets/datasets) as the following jars are getting cleaned. So that the "gobblin-PNDA-develop.tar.gz" contails only "gobblin-PNDA-develop.jar".

[root@ip-172-31-28-166 siva]# ls -lart
total 12376
-rw-r--r--.  1 root root 1411071 Jul 23 13:07 protobuf-java-3.5.1.jar
-rw-r--r--.  1 root root   64417 Jul 23 13:07 opencsv-3.8.jar
-rw-r--r--.  1 root root 1765905 Jul 23 13:07 kite-hadoop-compatibility-1.1.0.jar
-rw-r--r--.  1 root root 2178774 Jul 23 13:07 kite-data-core-1.1.0.jar
-rw-r--r--.  1 root root  397223 Jul 23 13:07 jgrapht-core-0.9.2.jar
-rw-r--r--.  1 root root  165868 Jul 23 13:07 JavaEWAH-1.1.6.jar
-rw-r--r--.  1 root root   41029 Jul 23 13:07 httpmime-4.5.2.jar
-rw-r--r--.  1 root root  267634 Jul 23 13:07 commons-jexl-2.1.1.jar

**Solution**
Remove "clean" from gradlew build. 

**Tested**
RHEL HDP